### PR TITLE
init_update_libs.sh: Update inactive links to libs

### DIFF
--- a/init_update_libs.sh
+++ b/init_update_libs.sh
@@ -4,14 +4,14 @@ echo "============================================"
 echo "Updating submodules"
 git submodule update --init
 echo "============================================"
-echo "Updating libpng, expat and fribidi"
+echo "Updating libpng, expat, fribidi and lame"
 rm -rf libpng-*
 rm -rf expat-*
 rm -rf fribidi-*
 rm -rf lame-*
 
-wget -O- ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng16/libpng-1.6.21.tar.xz | tar xJ
+wget -O- http://downloads.sourceforge.net/libpng/libpng-1.6.21.tar.xz | tar xJ
 wget -O- http://downloads.sourceforge.net/project/expat/expat/2.1.0/expat-2.1.0.tar.gz | tar xz
-wget -O- http://fribidi.org/download/fribidi-0.19.7.tar.bz2 | tar xj
+wget -O- https://github.com/fribidi/fribidi/releases/download/0.19.7/fribidi-0.19.7.tar.bz2 | tar xj
 wget -O- http://sourceforge.net/projects/lame/files/lame/3.99/lame-3.99.5.tar.gz | tar xz
 echo "============================================"


### PR DESCRIPTION
This updates the inactive links to libs like
`libpng` and `fribidi`.

Fixes https://github.com/WritingMinds/ffmpeg-android/issues/90